### PR TITLE
[init] 프로젝트 기초 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 ### VS Code ###
 .vscode/
 /src/main/resources/application.properties
+
+### QueryDsl 파일 ###
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     // === QueryDsl 시작 ===
     // == 스프링 부트 3.0 이상 ==
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
@@ -46,4 +46,22 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// === QueryDsl 빌드 옵션 (선택) ===
+def querydslDir = 'src/main/generated'
+
+// QClass가 위치할 경로 지정
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+// QueryDsl 소스 파일을 컴파일할 때 포함할 디렉토리를 설정
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+// 빌드 전에 이전에 생성된 QueryDsl 소스 파일을 정리합니다.
+clean {
+    delete file('src/main/generated')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,13 @@ repositories {
 }
 
 dependencies {
+    // === QueryDsl 시작 ===
+    // == 스프링 부트 3.0 이상 ==
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // GraphQL
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
     testImplementation 'org.springframework.graphql:spring-graphql-test'

--- a/src/main/java/com/twoPotatoes/bobJoying/common/config/QueryDslConfig.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/config/QueryDslConfig.java
@@ -8,6 +8,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
+// JPAQueryFactory를 사용하기 위해 Bean으로 등록
 @Configuration
 public class QueryDslConfig {
 

--- a/src/main/java/com/twoPotatoes/bobJoying/common/config/QueryDslConfig.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/config/QueryDslConfig.java
@@ -1,0 +1,22 @@
+package com.twoPotatoes.bobJoying.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomErrorCode.java
@@ -1,0 +1,19 @@
+package com.twoPotatoes.bobJoying.common.exception;
+
+import org.springframework.graphql.execution.ErrorType;
+
+import lombok.Getter;
+
+@Getter
+public enum CustomErrorCode {
+    // TODO : 예시 에러코드입니다. 필요하지 않으면 추후 삭제합니다.
+    USER_NOT_FOUND(ErrorType.NOT_FOUND, "사용자가 존재하지 않습니다.");
+
+    private final ErrorType errorType;
+    private final String message;
+
+    CustomErrorCode(ErrorType errorType, String message) {
+        this.errorType = errorType;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomException.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.twoPotatoes.bobJoying.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final CustomErrorCode errorCode;
+
+    public CustomException(CustomErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.twoPotatoes.bobJoying.common.exception;
+
+import org.springframework.graphql.data.method.annotation.GraphQlExceptionHandler;
+import org.springframework.graphql.execution.ErrorType;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import graphql.GraphQLError;
+
+// 컨트롤러에서 예외 발생시 여기서 핸들링하여 errorCode와 메시지를 리턴합니다.
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // CustomException 발생 시 작동하는 핸들러
+    @GraphQlExceptionHandler
+    public GraphQLError handle(CustomException ex) {
+        return GraphQLError.newError()
+            .errorType(ex.getErrorCode().getErrorType())
+            .message(ex.getMessage())
+            .build();
+    }
+}


### PR DESCRIPTION
## 관련 Issue

* close #16 

## 변경 사항

* QueryDsl 의존성을 추가하였습니다.
  * [QueryDsl 간단한 설명과 장점에 대해 쓴 블로그 글 링크](https://ittrue.tistory.com/292)
* QueryDsl Config 파일 생성
  * QueryDsl 라이브러리를 사용할 때 필요한 JPAQueryFactory를 매번 인스턴스를 생성할 필요없게끔 Bean으로 등록합니다.
* .gitignore에 QueryDsl로 생기는 Qclass 경로를 추가하였습니다.
  * Qclass 파일은 빌드 프로세스 중에 소스 코드로부터 생성되는 파일이라 git에서 관리할 필요가 없습니다.
* Controller 예외 처리 관련 파일 생성
  * CustomErrorCode
  * CustomException
  * GlobalExceptionHandler

## 테스트

다음처럼 컨트롤러 상에서 예외를 발생시킵니다.

![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/c5992232-0b65-4db6-8bdd-49e6beced827)

예외처리가 된 것을 확인합니다.

![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/6dea1fd3-d628-4e3f-8ae2-53df58e82993)

## 참고 사항

CustomErrorCode에서 쓰이는 ErrorType은 스프링에서 제공하는 에러타입인데 `BAD_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `INTERNAL_ERROR` Enum 5개로 관리하고 있습니다. 추후 디테일한 에러타입이 필요하다면 Custom하여 수정할 예정입니다.
