### PR TITLE
[feature] 로그아웃 구현

### DIFF
--- a/src/main/java/com/twoPotatoes/bobJoying/common/constants/AuthConstants.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/constants/AuthConstants.java
@@ -1,0 +1,13 @@
+package com.twoPotatoes.bobJoying.common.constants;
+
+public class AuthConstants {
+
+    // JWT constants
+    public static final String AUTHORIZATION_HEADER = "Authorization";       // Header KEY 값
+    public static final String AUTHORIZATION_KEY = "auth";      // 사용자 권한 값의 KEY
+    public static final String BEARER_PREFIX = "Bearer ";       // Token 식별자
+
+    // 토큰 만료시간
+    public static final long ACCESS_TOKEN_TIME = 30 * 60 * 1000L; // 30분
+    public static final long REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L; // 일주일
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/security/JwtUtil.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/security/JwtUtil.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import com.twoPotatoes.bobJoying.common.constants.AuthConstants;
 import com.twoPotatoes.bobJoying.common.exception.CustomErrorCode;
 import com.twoPotatoes.bobJoying.common.exception.CustomException;
 import com.twoPotatoes.bobJoying.member.entity.MemberRoleEnum;
@@ -26,15 +27,11 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @Component
 public class JwtUtil {
-    // Header KEY 값
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-    // 사용자 권한 값의 KEY
-    public static final String AUTHORIZATION_KEY = "auth";
-    // Token 식별자
-    public static final String BEARER_PREFIX = "Bearer ";
-    // 토큰 만료시간
-    private final long ACCESS_TOKEN_TIME = 30 * 60 * 1000L; // 30분
-    private final long REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L; // 일주일
+    private final String AUTHORIZATION_HEADER = AuthConstants.AUTHORIZATION_HEADER;
+    private final String AUTHORIZATION_KEY = AuthConstants.AUTHORIZATION_KEY;
+    private final String BEARER_PREFIX = AuthConstants.BEARER_PREFIX;
+    private final long ACCESS_TOKEN_TIME = AuthConstants.ACCESS_TOKEN_TIME;
+    private final long REFRESH_TOKEN_TIME = AuthConstants.REFRESH_TOKEN_TIME;
 
     @Value("${JWT_SECRET_KEY}") // Base64 Encode 한 SecretKey
     private String secretKey;

--- a/src/main/java/com/twoPotatoes/bobJoying/member/controller/AuthController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
         return authService.reissueToken(tokenRequestDto);
     }
 
-    @QueryMapping
+    @MutationMapping
     @PreAuthorize("isAuthenticated()")
     public String logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return authService.logout(userDetails.getMember());

--- a/src/main/java/com/twoPotatoes/bobJoying/member/controller/AuthController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/controller/AuthController.java
@@ -2,8 +2,12 @@ package com.twoPotatoes.bobJoying.member.controller;
 
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
+import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.member.dto.LoginRequestDto;
 import com.twoPotatoes.bobJoying.member.dto.TokenRequestDto;
 import com.twoPotatoes.bobJoying.member.dto.TokenResponseDto;
@@ -25,5 +29,11 @@ public class AuthController {
     @MutationMapping
     public TokenResponseDto reissueToken(@Argument @Valid TokenRequestDto tokenRequestDto) {
         return authService.reissueToken(tokenRequestDto);
+    }
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    public String logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return authService.logout(userDetails.getMember());
     }
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/member/controller/MemberController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/controller/MemberController.java
@@ -25,21 +25,7 @@ public class MemberController {
         return new ApiResponseDto("회원가입이 완료되었습니다.");
     }
 
-    // TODO: 테스트로 만든 메서드들. 후에 삭제
-    @QueryMapping
-    @PreAuthorize("isAuthenticated()")
-    public String onlyAuthenticated() {
-        return "only Authenticated";
-    }
-
-    @QueryMapping
-    @Secured("ROLE_ADMIN")
-    public String onlyAdmin() {
-        return "only Admin";
-    }
-
-    @QueryMapping
-    public String everyone() {
-        return "everyone";
-    }
+    // TODO: Method마다 인가 거는 방법
+    // @PreAuthorize("isAuthenticated()")
+    // @Secured("ROLE_ADMIN")
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/member/controller/MemberController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/controller/MemberController.java
@@ -2,9 +2,6 @@ package com.twoPotatoes.bobJoying.member.controller;
 
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
-import org.springframework.graphql.data.method.annotation.QueryMapping;
-import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;

--- a/src/main/java/com/twoPotatoes/bobJoying/member/entity/RefreshToken.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/entity/RefreshToken.java
@@ -3,10 +3,12 @@ package com.twoPotatoes.bobJoying.member.entity;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
+import com.twoPotatoes.bobJoying.common.constants.AuthConstants;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 7)   // 일주일
+@RedisHash(value = "refreshToken", timeToLive = AuthConstants.REFRESH_TOKEN_TIME)
 @Getter
 @AllArgsConstructor
 public class RefreshToken {

--- a/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthService.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthService.java
@@ -3,6 +3,7 @@ package com.twoPotatoes.bobJoying.member.service;
 import com.twoPotatoes.bobJoying.member.dto.LoginRequestDto;
 import com.twoPotatoes.bobJoying.member.dto.TokenRequestDto;
 import com.twoPotatoes.bobJoying.member.dto.TokenResponseDto;
+import com.twoPotatoes.bobJoying.member.entity.Member;
 
 public interface AuthService {
     /**
@@ -20,4 +21,12 @@ public interface AuthService {
      * @return 새로운 Access Token, 새로운 Refresh Token
      */
     TokenResponseDto reissueToken(TokenRequestDto tokenRequestDto);
+
+    /**
+     * 인증된 사용자의 저장되어 있던 Refresh Token 을 삭제합니다.
+     *
+     * @param member 인증된 사용자
+     * @return 로그아웃 성공 메시지
+     */
+    String logout(Member member);
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthServiceImpl.java
@@ -66,6 +66,12 @@ public class AuthServiceImpl implements AuthService {
         return new TokenResponseDto(newAccessToken, newRefreshToken, "토큰 재발급이 완료되었습니다.");
     }
 
+    @Override
+    public String logout(Member member) {
+        refreshTokenRepository.deleteById(member.getId());
+        return "로그아웃이 완료되었습니다.";
+    }
+
     private RefreshToken findRefreshToken(Integer id) {
         return refreshTokenRepository.findById(id).orElseThrow(
             () -> new CustomException(CustomErrorCode.INVALID_ACCESS)

--- a/src/main/resources/graphql/mutation.graphqls
+++ b/src/main/resources/graphql/mutation.graphqls
@@ -1,8 +1,9 @@
 type Mutation {
     # MemberController
-    signup(signupRequestDto: SignupRequestDto!): ApiResponseDto
+    signup(signupRequestDto: SignupRequestDto!): ApiResponseDto!
 
     # AuthController
-    login(loginRequestDto: LoginRequestDto!): TokenResponseDto
-    reissueToken(tokenRequestDto: TokenRequestDto!): TokenResponseDto
+    login(loginRequestDto: LoginRequestDto!): TokenResponseDto!
+    reissueToken(tokenRequestDto: TokenRequestDto!): TokenResponseDto!
+    logout: String!
 }

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -1,9 +1,3 @@
 type Query {
-    # TODO: 아래의 Query는 사용하지 않지만 스키마에서는 하나 이상의 쿼리를 정의해야 하기 때문에 해주었습니다. 후에 삭제예정
-    necessaryQuery(id: ID): String!
-
-    # TODO: 로그인 메서드 구현 예시 쿼리. 후에 삭제
-    onlyAuthenticated: String!
-    onlyAdmin: String!
-    everyone: String!
+    logout: String!
 }

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -1,3 +1,4 @@
+# TODO: 필수 쿼리. 후에 쿼리가 생기면 삭제
 type Query {
-    logout: String!
+    exampleQuery: String!
 }

--- a/src/test/java/com/twoPotatoes/bobJoying/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/member/controller/AuthControllerTest.java
@@ -12,8 +12,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.member.dto.TokenResponseDto;
+import com.twoPotatoes.bobJoying.member.entity.Member;
+import com.twoPotatoes.bobJoying.member.entity.MemberRoleEnum;
 import com.twoPotatoes.bobJoying.member.service.AuthService;
 
 @GraphQlTest(AuthController.class)
@@ -74,5 +79,29 @@ public class AuthControllerTest {
             .path("reissueToken.refreshToken")
             .entity(String.class)
             .isEqualTo(newRefreshToken);
+    }
+
+    @Test
+    @DisplayName("AuthController Test - logout")
+    void logout() {
+        // Given
+        Member member = Member.builder().role(MemberRoleEnum.MEMBER).build();
+        UserDetailsImpl userDetails = new UserDetailsImpl(member);
+        SecurityContextHolder
+            .getContext()
+            .setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+            );
+
+        String message = "로그아웃이 완료되었습니다.";
+        given(authService.logout(any(Member.class))).willReturn(message);
+
+        // When
+        graphQlTester.documentName("auth")
+            .operationName("logout")
+            .execute()
+            .path("logout")
+            .entity(String.class)
+            .isEqualTo(message);
     }
 }

--- a/src/test/java/com/twoPotatoes/bobJoying/member/service/AuthServiceTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/member/service/AuthServiceTest.java
@@ -193,7 +193,7 @@ public class AuthServiceTest {
         Member member = Member.builder().id(memberId).build();
 
         // When
-        String msg = authService.logout(member);
+        authService.logout(member);
 
         // Then
         then(refreshTokenRepository).should().deleteById(memberId);

--- a/src/test/java/com/twoPotatoes/bobJoying/member/service/AuthServiceTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/member/service/AuthServiceTest.java
@@ -184,4 +184,19 @@ public class AuthServiceTest {
         assertEquals(tokenResponseDto.getAccessToken(), newAccessToken);
         assertEquals(tokenResponseDto.getRefreshToken(), newRefreshToken);
     }
+
+    @Test
+    @DisplayName("logout 성공")
+    void logout() {
+        // Given
+        int memberId = 10;
+        Member member = Member.builder().id(memberId).build();
+
+        // When
+        String msg = authService.logout(member);
+
+        // Then
+        then(refreshTokenRepository).should().deleteById(memberId);
+        then(refreshTokenRepository).shouldHaveNoMoreInteractions();
+    }
 }

--- a/src/test/resources/graphql-test/auth.graphql
+++ b/src/test/resources/graphql-test/auth.graphql
@@ -13,3 +13,7 @@ mutation reissueToken($input: TokenRequestDto!){
         message
     }
 }
+
+query logout {
+    logout
+}

--- a/src/test/resources/graphql-test/auth.graphql
+++ b/src/test/resources/graphql-test/auth.graphql
@@ -14,6 +14,6 @@ mutation reissueToken($input: TokenRequestDto!){
     }
 }
 
-query logout {
+mutation logout {
     logout
 }


### PR DESCRIPTION
<!-- PR을 먼저 제출하고 내용을 작성하면 CI 기다리는 시간을 줄일 수 있어요! -->

# 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* close #41 

# 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

### 기능
* logout 구현 - header의 Access Token에서 멤버 정보를 가져와 저장되어 있는 RefreshToken 삭제

1. 로그인을 하면 AT와 RT 발급

![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/9fc59912-1418-403b-bb93-b8aee7cca674)

2. RT가 Redis에 저장

![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/e7cedc73-cef5-4a6d-b3db-2f5fb7f04f7e)

3. AT를 Authorization 키에 Header에 Set

![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/70ff69fd-1610-4857-8b40-fbcef3a88c35)

4. logout 쿼리 요청 - 성공 메시지 return

|쿼리 요청|성공 메시지|
|---|---|
|![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/4e19c76d-05e7-4c1a-9a20-95a400395fe4)|![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/4a44350a-1c7a-4c16-a598-569afbf966b5)|

5. Redis에서 해당 멤버 RT가 삭제됨을 확인할 수 있다.

![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/e46248bc-555e-4564-9f14-17ad98cc3db3)


### 리팩터링
* login 할 때 email이 올바르지 않으면 "멤버가 존재하지 않습니다."로 과한 정보를 반환해주고 있다고 판단
  * -> try - catch로 다른 예외를 반환하도록 함
  * 현재 email이 올바르지 않든, 비밀번호가 올바르지 않든 둘 다 잘못된 접근입니다. 라는 메시지 반환

![image](https://github.com/Two-Potatoes/BobJoying-Back/assets/130378232/e0eba170-5cd0-4835-821d-179bf026541f)

* 상수 관리 패키지, 파일 생성

### 테스트 코드
* logout 테스트 코드 작성
  * AuthController, AuthServiceImpl에 대한 테스트 코드

- [x] 로컬에서 build test를 해보았나요?
- [x] 구현한 기능을 로컬에서 test해보았나요?
- [x] 도커에서 build test를 해보았나요?
- [x] 구현한 기능을 도커에서 test해보았나요?
- [x] 테스트 코드를 작성하였나요?