### PR TITLE
[feature] 내 재료 등록 API 구현 및 메시지 상수화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    // GraphQL Extended Scalar
+    implementation 'com.graphql-java:graphql-java-extended-scalars:22.0'
+
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    // H2
+    runtimeOnly 'com.h2database:h2'
+
     // GraphQL Extended Scalar
     implementation 'com.graphql-java:graphql-java-extended-scalars:22.0'
 

--- a/src/main/java/com/twoPotatoes/bobJoying/common/config/GraphQlConfig.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/config/GraphQlConfig.java
@@ -1,0 +1,16 @@
+package com.twoPotatoes.bobJoying.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.graphql.execution.RuntimeWiringConfigurer;
+
+import graphql.scalars.ExtendedScalars;
+
+@Configuration
+public class GraphQlConfig {
+    @Bean
+    public RuntimeWiringConfigurer runtimeWiringConfigurer() {
+        // GraphQL Schema에 Date 타입을 추가합니다.
+        return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.Date);
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/constants/ErrorMsgConstants.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/constants/ErrorMsgConstants.java
@@ -1,0 +1,13 @@
+package com.twoPotatoes.bobJoying.common.constants;
+
+public class ErrorMsgConstants {
+    // Custom Error Message
+    public static final String ACCOUNT_ALREADY_EXISTS = "이미 가입한 계정입니다.";
+    public static final String INVALID_ACCESS = "잘못된 접근입니다.";
+    public static final String MEMBER_NOT_FOUND = "멤버가 존재하지 않습니다.";
+    public static final String LOGIN_REQUEST = "다시 로그인해주세요.";
+    public static final String INGREDIENT_NOT_FOUND = "해당 재료는 존재하지 않습니다.";
+    public static final String INVALID_QUANTITY = "수량은 소수점 첫째 자리까지 가능합니다.";
+    public static final String INVALID_EXPIRATION_DATE = "소비 기한은 저장 날 이후의 날짜를 입력해야 합니다.";
+    public static final String INVALID_UNIT = "단위는 10자를 초과할 수 없습니다.";
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/constants/MemberConstants.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/constants/MemberConstants.java
@@ -1,0 +1,19 @@
+package com.twoPotatoes.bobJoying.common.constants;
+
+public class MemberConstants {
+    // Response Message
+    public static final String SIGNUP_SUCCESS = "회원가입이 완료되었습니다.";
+    public static final String LOGIN_SUCCESS = "로그인이 완료되었습니다.";
+    public static final String REISSUE_TOKEN_SUCCESS = "토큰 재발급이 완료되었습니다.";
+    public static final String LOGOUT_SUCCESS = "로그아웃이 완료되었습니다.";
+
+    // Validation
+    public static final String EMAIL_NOT_BLANK = "이메일 칸은 비울 수 없습니다.";
+    public static final String INVALID_EMAIL = "올바른 이메일 형식이 아닙니다.";
+    public static final String PASSWORD_NOT_BLANK = "비밀번호 칸은 비울 수 없습니다.";
+    public static final String TOO_SHORT_PASSWORD = "비밀번호는 8자 이상이어야 합니다.";
+    public static final String PASSWORD_REGULAR_EXPRESSION = "^(?=.*[a-z])(?=.*\\d)(?=.*[!?@#$%^&*_=+-]).+$";
+    public static final String INVALID_PASSWORD = "비밀번호는 영소문자, 숫자, 특수문자(!,?,@,#,$,%,^,&,*,_,=,+,-)가 한 개 이상 포함되어야 합니다.";
+    public static final String NICKNAME_NOT_BLANK = "닉네임 칸은 비울 수 없습니다.";
+    public static final String BLANK_NOT_ALLOWED = "빈 값이 들어올 수 없습니다.";
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/constants/MyIngredientConstants.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/constants/MyIngredientConstants.java
@@ -1,0 +1,15 @@
+package com.twoPotatoes.bobJoying.common.constants;
+
+public class MyIngredientConstants {
+    // Validation
+    public static final String INVALID_UNIT = "단위는 10자를 넘어갈 수 없습니다.";
+    public static final String INVALID_INGREDIENT_ID = "id는 1이상이어야 합니다.";
+
+    // StorageEnum
+    public static final String FRIDGE = "냉장";
+    public static final String FREEZER = "냉동";
+    public static final String ROOM_TEMPERATURE = "실온";
+
+    // Response Message
+    public static final String CREATE_MY_INGREDIENT_SUCCESS = "재료 등록이 완료되었습니다.";
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomErrorCode.java
@@ -2,18 +2,20 @@ package com.twoPotatoes.bobJoying.common.exception;
 
 import org.springframework.graphql.execution.ErrorType;
 
+import com.twoPotatoes.bobJoying.common.constants.ErrorMsgConstants;
+
 import lombok.Getter;
 
 @Getter
 public enum CustomErrorCode {
-    ACCOUNT_ALREADY_EXISTS(ErrorType.BAD_REQUEST, "이미 가입한 계정입니다."),
-    INVALID_ACCESS(ErrorType.BAD_REQUEST, "잘못된 접근입니다."),
-    MEMBER_NOT_FOUND(ErrorType.NOT_FOUND, "멤버가 존재하지 않습니다."),
-    LOGIN_REQUEST(ErrorType.BAD_REQUEST, "다시 로그인해주세요."),
-    INGREDIENT_NOT_FOUND(ErrorType.NOT_FOUND, "해당 재료는 존재하지 않습니다."),
-    INVALID_QUANTITY(ErrorType.BAD_REQUEST, "수량은 소수점 첫째 자리까지 가능합니다."),
-    INVALID_EXPIRATION_DATE(ErrorType.BAD_REQUEST, "소비 기한은 저장 날 이후의 날짜를 입력해야 합니다."),
-    INVALID_UNIT(ErrorType.BAD_REQUEST, "단위는 10자를 초과할 수 없습니다.");
+    ACCOUNT_ALREADY_EXISTS(ErrorType.BAD_REQUEST, ErrorMsgConstants.ACCOUNT_ALREADY_EXISTS),
+    INVALID_ACCESS(ErrorType.BAD_REQUEST, ErrorMsgConstants.INVALID_ACCESS),
+    MEMBER_NOT_FOUND(ErrorType.NOT_FOUND, ErrorMsgConstants.MEMBER_NOT_FOUND),
+    LOGIN_REQUEST(ErrorType.BAD_REQUEST, ErrorMsgConstants.LOGIN_REQUEST),
+    INGREDIENT_NOT_FOUND(ErrorType.NOT_FOUND, ErrorMsgConstants.INGREDIENT_NOT_FOUND),
+    INVALID_QUANTITY(ErrorType.BAD_REQUEST, ErrorMsgConstants.INVALID_QUANTITY),
+    INVALID_EXPIRATION_DATE(ErrorType.BAD_REQUEST, ErrorMsgConstants.INVALID_EXPIRATION_DATE),
+    INVALID_UNIT(ErrorType.BAD_REQUEST, ErrorMsgConstants.INVALID_UNIT);
 
     private final ErrorType errorType;
     private final String message;

--- a/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomErrorCode.java
@@ -9,7 +9,11 @@ public enum CustomErrorCode {
     ACCOUNT_ALREADY_EXISTS(ErrorType.BAD_REQUEST, "이미 가입한 계정입니다."),
     INVALID_ACCESS(ErrorType.BAD_REQUEST, "잘못된 접근입니다."),
     MEMBER_NOT_FOUND(ErrorType.NOT_FOUND, "멤버가 존재하지 않습니다."),
-    LOGIN_REQUEST(ErrorType.BAD_REQUEST, "다시 로그인해주세요.");
+    LOGIN_REQUEST(ErrorType.BAD_REQUEST, "다시 로그인해주세요."),
+    INGREDIENT_NOT_FOUND(ErrorType.NOT_FOUND, "해당 재료는 존재하지 않습니다."),
+    INVALID_QUANTITY(ErrorType.BAD_REQUEST, "수량은 소수점 첫째 자리까지 가능합니다."),
+    INVALID_EXPIRATION_DATE(ErrorType.BAD_REQUEST, "소비 기한은 저장 날 이후의 날짜를 입력해야 합니다."),
+    INVALID_UNIT(ErrorType.BAD_REQUEST, "단위는 10자를 초과할 수 없습니다.");
 
     private final ErrorType errorType;
     private final String message;

--- a/src/main/java/com/twoPotatoes/bobJoying/common/security/SecurityConfig.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/security/SecurityConfig.java
@@ -9,6 +9,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +26,18 @@ public class SecurityConfig {
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
         return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("http://localhost:3000");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
     }
 
     @Bean

--- a/src/main/java/com/twoPotatoes/bobJoying/common/security/SecurityConfig.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -42,6 +43,12 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain configure(HttpSecurity http) throws Exception {
+        // H2-console web 연결 옵션
+        http.headers(
+            headersConfigurer ->
+                headersConfigurer.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+        );
+
         // Cross-Site Request Forgery(CSRF) 방지 기능 비활성화
         // 활성화시 html에서 csrf 토큰이 포함되어야 요청을 받아들임
         http.csrf(AbstractHttpConfigurer::disable);
@@ -56,7 +63,7 @@ public class SecurityConfig {
             authorizeHttpRequests
                 .requestMatchers("/graphql").permitAll()
                 .requestMatchers("/graphiql").permitAll()
-                .requestMatchers("/h2-console").permitAll()
+                .requestMatchers("/h2-console/**", "/favicon.ico").permitAll()
                 .anyRequest().denyAll()
         );
 

--- a/src/main/java/com/twoPotatoes/bobJoying/common/security/WebConfig.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/security/WebConfig.java
@@ -1,0 +1,17 @@
+package com.twoPotatoes.bobJoying.common.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientController.java
@@ -1,0 +1,30 @@
+package com.twoPotatoes.bobJoying.ingredient.controller;
+
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientResponseDto;
+import com.twoPotatoes.bobJoying.ingredient.service.MyIngredientService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class MyIngredientController {
+    private final MyIngredientService myIngredientService;
+
+    @MutationMapping
+    @PreAuthorize("isAuthenticated()")
+    public ApiResponseDto createMyIngredient(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Argument @Valid MyIngredientCreateRequestDto myIngredientCreateRequestDto) {
+        return myIngredientService.createMyIngredient(userDetails, myIngredientCreateRequestDto);
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientController.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Controller;
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
-import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.service.MyIngredientService;
 
 import jakarta.validation.Valid;

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientBaseDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientBaseDto.java
@@ -1,0 +1,24 @@
+package com.twoPotatoes.bobJoying.ingredient.dto;
+
+import java.time.LocalDate;
+
+import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public abstract class MyIngredientBaseDto {
+    private float quantity;
+    @Size(max = 10, message = "단위는 10자를 넘어갈 수 없습니다.")
+    private String unit;
+    private LocalDate storageDate;
+    private LocalDate expirationDate;
+    private StorageEnum storage;
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientBaseDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientBaseDto.java
@@ -2,6 +2,7 @@ package com.twoPotatoes.bobJoying.ingredient.dto;
 
 import java.time.LocalDate;
 
+import com.twoPotatoes.bobJoying.common.constants.MyIngredientConstants;
 import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
 
 import jakarta.validation.constraints.Size;
@@ -16,7 +17,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public abstract class MyIngredientBaseDto {
     private float quantity;
-    @Size(max = 10, message = "단위는 10자를 넘어갈 수 없습니다.")
+    @Size(max = 10, message = MyIngredientConstants.INVALID_UNIT)
     private String unit;
     private LocalDate storageDate;
     private LocalDate expirationDate;

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientCreateRequestDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientCreateRequestDto.java
@@ -1,0 +1,16 @@
+package com.twoPotatoes.bobJoying.ingredient.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public class MyIngredientCreateRequestDto extends MyIngredientBaseDto {
+    @Min(value = 1, message = "id는 1이상이어야 합니다.")
+    private int ingredientId;
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientCreateRequestDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientCreateRequestDto.java
@@ -1,5 +1,7 @@
 package com.twoPotatoes.bobJoying.ingredient.dto;
 
+import com.twoPotatoes.bobJoying.common.constants.MyIngredientConstants;
+
 import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +13,6 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 public class MyIngredientCreateRequestDto extends MyIngredientBaseDto {
-    @Min(value = 1, message = "id는 1이상이어야 합니다.")
+    @Min(value = 1, message = MyIngredientConstants.INVALID_INGREDIENT_ID)
     private int ingredientId;
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/Ingredient.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/Ingredient.java
@@ -7,6 +7,8 @@ import com.twoPotatoes.bobJoying.recipe.entity.RecipeIngredient;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,8 +34,9 @@ public class Ingredient {
     @Column(nullable = false)
     private String name;
 
+    @Enumerated(value = EnumType.STRING)
     @Column(nullable = false, length = 100)
-    private String storageArea;
+    private StorageEnum storage;
 
     // cascade 옵션을 걸어주지 않습니다. 잘못하다가 유저들의 정보가 삭제될 수도 있기 때문입니다.
     @OneToMany(mappedBy = "ingredient")

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/MyIngredient.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/MyIngredient.java
@@ -6,6 +6,8 @@ import com.twoPotatoes.bobJoying.member.entity.Member;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -45,6 +47,7 @@ public class MyIngredient {
 
     private LocalDate expirationDate;
 
+    @Enumerated(value = EnumType.STRING)
     @Column(nullable = false, length = 100)
-    private String storageArea;
+    private StorageEnum storage;
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/StorageEnum.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/StorageEnum.java
@@ -1,12 +1,14 @@
 package com.twoPotatoes.bobJoying.ingredient.entity;
 
+import com.twoPotatoes.bobJoying.common.constants.MyIngredientConstants;
+
 import lombok.Getter;
 
 @Getter
 public enum StorageEnum {
-    FRIDGE("냉장"),
-    FREEZER("냉동"),
-    ROOM_TEMPERATURE("실온");
+    FRIDGE(MyIngredientConstants.FRIDGE),
+    FREEZER(MyIngredientConstants.FREEZER),
+    ROOM_TEMPERATURE(MyIngredientConstants.ROOM_TEMPERATURE);
 
     private final String storage;
 

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/StorageEnum.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/StorageEnum.java
@@ -1,0 +1,16 @@
+package com.twoPotatoes.bobJoying.ingredient.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum StorageEnum {
+    FRIDGE("냉장"),
+    FREEZER("냉동"),
+    ROOM_TEMPERATURE("실온");
+
+    private final String storage;
+
+    StorageEnum(String storage) {
+        this.storage = storage;
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/IngredientRepository.java
@@ -1,0 +1,10 @@
+package com.twoPotatoes.bobJoying.ingredient.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.twoPotatoes.bobJoying.ingredient.entity.Ingredient;
+
+@Repository
+public interface IngredientRepository extends JpaRepository<Ingredient, Integer> {
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/MyIngredientRepository.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/MyIngredientRepository.java
@@ -1,0 +1,8 @@
+package com.twoPotatoes.bobJoying.ingredient.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.twoPotatoes.bobJoying.ingredient.entity.MyIngredient;
+
+public interface MyIngredientRepository extends JpaRepository<MyIngredient, Integer> {
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientService.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientService.java
@@ -1,0 +1,16 @@
+package com.twoPotatoes.bobJoying.ingredient.service;
+
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+
+public interface MyIngredientService {
+    /**
+     * 필요한 정보를 받아 정보에 맞는 식재료를 등록합니다.
+     *
+     * @param userDetails   인증된 사용자 정보
+     * @param requestDto    식재료 등록에 필요한 정보
+     * @return 식재료 등록 성공 메시지
+     */
+    ApiResponseDto createMyIngredient(UserDetailsImpl userDetails, MyIngredientCreateRequestDto requestDto);
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceImpl.java
@@ -2,6 +2,7 @@ package com.twoPotatoes.bobJoying.ingredient.service;
 
 import org.springframework.stereotype.Service;
 
+import com.twoPotatoes.bobJoying.common.constants.MyIngredientConstants;
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.exception.CustomErrorCode;
 import com.twoPotatoes.bobJoying.common.exception.CustomException;
@@ -36,7 +37,7 @@ public class MyIngredientServiceImpl implements MyIngredientService {
             .storage(requestDto.getStorage())
             .build();
         myIngredientRepository.save(myIngredient);
-        return new ApiResponseDto("재료 등록이 완료되었습니다.");
+        return new ApiResponseDto(MyIngredientConstants.CREATE_MY_INGREDIENT_SUCCESS);
     }
 
     private void validateRequest(MyIngredientCreateRequestDto requestDto) {

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceImpl.java
@@ -1,0 +1,60 @@
+package com.twoPotatoes.bobJoying.ingredient.service;
+
+import org.springframework.stereotype.Service;
+
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.exception.CustomErrorCode;
+import com.twoPotatoes.bobJoying.common.exception.CustomException;
+import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.entity.Ingredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.MyIngredient;
+import com.twoPotatoes.bobJoying.ingredient.repository.IngredientRepository;
+import com.twoPotatoes.bobJoying.ingredient.repository.MyIngredientRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MyIngredientServiceImpl implements MyIngredientService {
+    private final MyIngredientRepository myIngredientRepository;
+    private final IngredientRepository ingredientRepository;
+
+    @Override
+    public ApiResponseDto createMyIngredient(UserDetailsImpl userDetails, MyIngredientCreateRequestDto requestDto) {
+        validateRequest(requestDto);
+        Ingredient ingredient = findIngredient(requestDto.getIngredientId());
+        MyIngredient myIngredient = MyIngredient.builder()
+            .member(userDetails.getMember())
+            .ingredient(ingredient)
+            .quantity(requestDto.getQuantity())
+            .unit(requestDto.getUnit())
+            .storageDate(requestDto.getStorageDate())
+            .expirationDate(requestDto.getExpirationDate())
+            .storage(requestDto.getStorage())
+            .build();
+        myIngredientRepository.save(myIngredient);
+        return new ApiResponseDto("재료 등록이 완료되었습니다.");
+    }
+
+    private void validateRequest(MyIngredientCreateRequestDto requestDto) {
+        // quantity는 소수점 첫째 자리까지 허용한다.
+        if ((requestDto.getQuantity() * 10) % 1 != 0) {
+            throw new CustomException(CustomErrorCode.INVALID_QUANTITY);
+        }
+        // 소비기한이 null이 아닌 경우 식재료 등록 날짜는 소비기한을 넘길 수 없다.
+        if (requestDto.getExpirationDate() != null) {
+            if (requestDto.getExpirationDate().isBefore(requestDto.getStorageDate())) {
+                throw new CustomException(CustomErrorCode.INVALID_EXPIRATION_DATE);
+            }
+        }
+    }
+
+    private Ingredient findIngredient(int id) {
+        return ingredientRepository.findById(id).orElseThrow(
+            () -> new CustomException(CustomErrorCode.INGREDIENT_NOT_FOUND)
+        );
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/member/controller/AuthController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/controller/AuthController.java
@@ -2,11 +2,11 @@ package com.twoPotatoes.bobJoying.member.controller;
 
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
-import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.member.dto.LoginRequestDto;
 import com.twoPotatoes.bobJoying.member.dto.TokenRequestDto;
@@ -33,7 +33,7 @@ public class AuthController {
 
     @MutationMapping
     @PreAuthorize("isAuthenticated()")
-    public String logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ApiResponseDto logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         return authService.logout(userDetails.getMember());
     }
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/member/controller/MemberController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.stereotype.Controller;
 
+import com.twoPotatoes.bobJoying.common.constants.MemberConstants;
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.member.dto.SignupRequestDto;
 import com.twoPotatoes.bobJoying.member.service.MemberService;
@@ -19,7 +20,7 @@ public class MemberController {
     @MutationMapping
     public ApiResponseDto signup(@Argument @Valid SignupRequestDto signupRequestDto) {
         memberService.signup(signupRequestDto);
-        return new ApiResponseDto("회원가입이 완료되었습니다.");
+        return new ApiResponseDto(MemberConstants.SIGNUP_SUCCESS);
     }
 
     // TODO: Method마다 인가 거는 방법

--- a/src/main/java/com/twoPotatoes/bobJoying/member/dto/LoginRequestDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/dto/LoginRequestDto.java
@@ -1,5 +1,7 @@
 package com.twoPotatoes.bobJoying.member.dto;
 
+import com.twoPotatoes.bobJoying.common.constants.MemberConstants;
+
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,10 +12,10 @@ import lombok.Setter;
 @Builder
 public class LoginRequestDto {
 
-    @NotBlank(message = "이메일 칸은 비울 수 없습니다.")
+    @NotBlank(message = MemberConstants.EMAIL_NOT_BLANK)
     private String email;
 
-    @NotBlank(message = "비밀번호 칸은 비울 수 없습니다.")
+    @NotBlank(message = MemberConstants.PASSWORD_NOT_BLANK)
     private String password;
 
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/member/dto/SignupRequestDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/dto/SignupRequestDto.java
@@ -1,5 +1,7 @@
 package com.twoPotatoes.bobJoying.member.dto;
 
+import com.twoPotatoes.bobJoying.common.constants.MemberConstants;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -14,19 +16,19 @@ import lombok.Setter;
 public class SignupRequestDto {
     @Email(
         regexp = "^.+@.+\\..+$",
-        message = "올바른 이메일 형식이 아닙니다."
+        message = MemberConstants.INVALID_EMAIL
     )
-    @NotBlank(message = "이메일 칸은 비울 수 없습니다.")
+    @NotBlank(message = MemberConstants.EMAIL_NOT_BLANK)
     private String email;
 
-    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    @Size(min = 8, message = MemberConstants.TOO_SHORT_PASSWORD)
     @Pattern(
-        regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!?@#$%^&*_=+-]).+$",
-        message = "비밀번호는 영소문자, 숫자, 특수문자(!,?,@,#,$,%,^,&,*,_,=,+,-)가 한 개 이상 포함되어야 합니다.")
-    @NotBlank(message = "비밀번호 칸은 비울 수 없습니다.")
+        regexp = MemberConstants.PASSWORD_REGULAR_EXPRESSION,
+        message = MemberConstants.INVALID_PASSWORD)
+    @NotBlank(message = MemberConstants.PASSWORD_NOT_BLANK)
     private String password;
 
-    @NotBlank(message = "닉네임 칸은 비울 수 없습니다.")
+    @NotBlank(message = MemberConstants.NICKNAME_NOT_BLANK)
     private String nickname;
 
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/member/dto/TokenRequestDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/dto/TokenRequestDto.java
@@ -1,5 +1,7 @@
 package com.twoPotatoes.bobJoying.member.dto;
 
+import com.twoPotatoes.bobJoying.common.constants.MemberConstants;
+
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
@@ -7,8 +9,8 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TokenRequestDto {
-    @NotBlank(message = "빈 값이 들어올 수 없습니다.")
+    @NotBlank(message = MemberConstants.BLANK_NOT_ALLOWED)
     private String accessToken;
-    @NotBlank(message = "빈 값이 들어올 수 없습니다.")
+    @NotBlank(message = MemberConstants.BLANK_NOT_ALLOWED)
     private String refreshToken;
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthService.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.twoPotatoes.bobJoying.member.service;
 
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.member.dto.LoginRequestDto;
 import com.twoPotatoes.bobJoying.member.dto.TokenRequestDto;
 import com.twoPotatoes.bobJoying.member.dto.TokenResponseDto;
@@ -28,5 +29,5 @@ public interface AuthService {
      * @param member 인증된 사용자
      * @return 로그아웃 성공 메시지
      */
-    String logout(Member member);
+    ApiResponseDto logout(Member member);
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.twoPotatoes.bobJoying.member.service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.exception.CustomErrorCode;
 import com.twoPotatoes.bobJoying.common.exception.CustomException;
 import com.twoPotatoes.bobJoying.common.security.JwtUtil;
@@ -70,9 +71,9 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public String logout(Member member) {
+    public ApiResponseDto logout(Member member) {
         refreshTokenRepository.deleteById(member.getId());
-        return "로그아웃이 완료되었습니다.";
+        return new ApiResponseDto("로그아웃이 완료되었습니다.");
     }
 
     private void checkPassword(String rawPassword, String encodedPassword) {

--- a/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/member/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.twoPotatoes.bobJoying.member.service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.twoPotatoes.bobJoying.common.constants.MemberConstants;
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.exception.CustomErrorCode;
 import com.twoPotatoes.bobJoying.common.exception.CustomException;
@@ -41,7 +42,7 @@ public class AuthServiceImpl implements AuthService {
         RefreshToken memberToken = new RefreshToken(member.getId(), refreshToken);
         refreshTokenRepository.save(memberToken);
 
-        return new TokenResponseDto(accessToken, refreshToken, "로그인이 완료되었습니다.");
+        return new TokenResponseDto(accessToken, refreshToken, MemberConstants.LOGIN_SUCCESS);
     }
 
     @Override
@@ -67,13 +68,13 @@ public class AuthServiceImpl implements AuthService {
         String newRefreshToken = jwtUtil.createRefreshToken();
         String newAccessToken = jwtUtil.createAccessToken(email, member.getRole());
         refreshTokenRepository.save(new RefreshToken(member.getId(), newRefreshToken));
-        return new TokenResponseDto(newAccessToken, newRefreshToken, "토큰 재발급이 완료되었습니다.");
+        return new TokenResponseDto(newAccessToken, newRefreshToken, MemberConstants.REISSUE_TOKEN_SUCCESS);
     }
 
     @Override
     public ApiResponseDto logout(Member member) {
         refreshTokenRepository.deleteById(member.getId());
-        return new ApiResponseDto("로그아웃이 완료되었습니다.");
+        return new ApiResponseDto(MemberConstants.LOGOUT_SUCCESS);
     }
 
     private void checkPassword(String rawPassword, String encodedPassword) {

--- a/src/main/resources/graphql/common/commonDto.graphqls
+++ b/src/main/resources/graphql/common/commonDto.graphqls
@@ -1,3 +1,5 @@
+scalar Date
+
 type ApiResponseDto {
     message: String!
 }

--- a/src/main/resources/graphql/ingredient/ingredientDto.graphqls
+++ b/src/main/resources/graphql/ingredient/ingredientDto.graphqls
@@ -1,0 +1,14 @@
+enum StorageEnum {
+    FRIDGE
+    FREEZER
+    ROOM_TEMPERATURE
+}
+
+input MyIngredientCreateRequestDto {
+    quantity: Float!
+    unit: String!
+    storageDate: Date!
+    expirationDate: Date
+    storage: StorageEnum!
+    ingredientId: Int!
+}

--- a/src/main/resources/graphql/mutation.graphqls
+++ b/src/main/resources/graphql/mutation.graphqls
@@ -1,9 +1,12 @@
 type Mutation {
     # MemberController
-    signup(signupRequestDto: SignupRequestDto!): ApiResponseDto!
+    signup(signupRequestDto: SignupRequestDto!): ApiResponseDto
 
     # AuthController
-    login(loginRequestDto: LoginRequestDto!): TokenResponseDto!
-    reissueToken(tokenRequestDto: TokenRequestDto!): TokenResponseDto!
-    logout: ApiResponseDto!
+    login(loginRequestDto: LoginRequestDto!): TokenResponseDto
+    reissueToken(tokenRequestDto: TokenRequestDto!): TokenResponseDto
+    logout: ApiResponseDto
+
+    # MyIngredientController
+    createMyIngredient(myIngredientCreateRequestDto: MyIngredientCreateRequestDto!): ApiResponseDto
 }

--- a/src/main/resources/graphql/mutation.graphqls
+++ b/src/main/resources/graphql/mutation.graphqls
@@ -5,5 +5,5 @@ type Mutation {
     # AuthController
     login(loginRequestDto: LoginRequestDto!): TokenResponseDto!
     reissueToken(tokenRequestDto: TokenRequestDto!): TokenResponseDto!
-    logout: String!
+    logout: ApiResponseDto!
 }

--- a/src/test/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientControllerTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientControllerTest.java
@@ -1,10 +1,8 @@
 package com.twoPotatoes.bobJoying.ingredient.controller;
 
 import static com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,7 +21,6 @@ import com.twoPotatoes.bobJoying.common.config.GraphQlConfig;
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
-import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
 import com.twoPotatoes.bobJoying.ingredient.service.MyIngredientService;
 import com.twoPotatoes.bobJoying.member.entity.Member;
 import com.twoPotatoes.bobJoying.member.entity.MemberRoleEnum;

--- a/src/test/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientControllerTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientControllerTest.java
@@ -1,0 +1,83 @@
+package com.twoPotatoes.bobJoying.ingredient.controller;
+
+import static com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.twoPotatoes.bobJoying.common.config.GraphQlConfig;
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
+import com.twoPotatoes.bobJoying.ingredient.service.MyIngredientService;
+import com.twoPotatoes.bobJoying.member.entity.Member;
+import com.twoPotatoes.bobJoying.member.entity.MemberRoleEnum;
+
+@GraphQlTest(MyIngredientController.class)
+@Import(GraphQlConfig.class)
+class MyIngredientControllerTest {
+    @Autowired
+    private GraphQlTester graphQlTester;
+
+    @MockBean
+    private MyIngredientService myIngredientService;
+    UserDetailsImpl userDetails;
+    ApiResponseDto apiResponseDto;
+
+    @BeforeEach
+    void setUp() {
+        Member member = Member.builder().role(MemberRoleEnum.MEMBER).build();
+        userDetails = new UserDetailsImpl(member);
+        SecurityContextHolder
+            .getContext()
+            .setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities()
+                )
+            );
+        apiResponseDto = new ApiResponseDto("요청 성공!");
+    }
+
+    @Test
+    @DisplayName("MyIngredientController Test - createMyIngredient")
+    void createMyIngredient() {
+        // given
+        Map<String, Object> createRequestDto = new HashMap<>();
+
+        createRequestDto.put("ingredientId", 1);
+        createRequestDto.put("quantity", 1.5f);
+        createRequestDto.put("unit", "개");
+        createRequestDto.put("storageDate", "2024-05-17");
+        createRequestDto.put("expirationDate", "2024-05-27");
+        createRequestDto.put("storage", FRIDGE);
+
+        given(myIngredientService.createMyIngredient(
+                any(UserDetailsImpl.class),
+                any(MyIngredientCreateRequestDto.class)
+            )
+        ).willReturn(apiResponseDto);
+
+        // when
+        graphQlTester.documentName("myIngredient")
+            .variable("input", createRequestDto)
+            .operationName("createMyIngredient")
+            .execute()
+            .path("createMyIngredient.message")
+            .entity(String.class);
+    }
+}

--- a/src/test/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceTest.java
@@ -14,7 +14,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.exception.CustomException;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
@@ -24,7 +23,6 @@ import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
 import com.twoPotatoes.bobJoying.ingredient.repository.IngredientRepository;
 import com.twoPotatoes.bobJoying.ingredient.repository.MyIngredientRepository;
 import com.twoPotatoes.bobJoying.member.entity.Member;
-import com.twoPotatoes.bobJoying.member.entity.MemberRoleEnum;
 
 @ExtendWith(MockitoExtension.class)
 class MyIngredientServiceTest {

--- a/src/test/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceTest.java
@@ -1,0 +1,109 @@
+package com.twoPotatoes.bobJoying.ingredient.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.exception.CustomException;
+import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.entity.Ingredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.MyIngredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
+import com.twoPotatoes.bobJoying.ingredient.repository.IngredientRepository;
+import com.twoPotatoes.bobJoying.ingredient.repository.MyIngredientRepository;
+import com.twoPotatoes.bobJoying.member.entity.Member;
+import com.twoPotatoes.bobJoying.member.entity.MemberRoleEnum;
+
+@ExtendWith(MockitoExtension.class)
+class MyIngredientServiceTest {
+    @Mock
+    MyIngredientRepository myIngredientRepository;
+    @Mock
+    IngredientRepository ingredientRepository;
+    @InjectMocks
+    MyIngredientServiceImpl myIngredientService;
+    MyIngredientCreateRequestDto createRequestDto;
+    UserDetailsImpl userDetails;
+
+    @BeforeEach
+    void setUp() {
+        createRequestDto = MyIngredientCreateRequestDto.builder()
+            .ingredientId(1)
+            .quantity(1)
+            .unit("개")
+            .storageDate(LocalDate.of(2024, 5, 7))
+            .expirationDate(LocalDate.of(2024, 5, 27))
+            .storage(StorageEnum.FRIDGE)
+            .build();
+        Member member = Member.builder().id(1).build();
+        userDetails = new UserDetailsImpl(member);
+    }
+
+    @Test
+    @DisplayName("createMyIngredient - quantity는 소수점 첫째 자리까지 허용한다.")
+    void createMyIngredientFailByQuantity() {
+        // given
+        createRequestDto.setQuantity(1.25f);
+
+        // when
+        assertThrows(
+            CustomException.class,
+            () -> myIngredientService.createMyIngredient(userDetails, createRequestDto)
+        );
+    }
+
+    @Test
+    @DisplayName("createMyIngredient - 식재료 등록 날짜는 소비기한을 넘길 수 없다.")
+    void createMyIngredientFailByExpirationDate() {
+        // given
+        createRequestDto.setStorageDate(LocalDate.of(2024, 5, 27));
+        createRequestDto.setExpirationDate(LocalDate.of(2024, 5, 20));
+
+        // when
+        assertThrows(
+            CustomException.class,
+            () -> myIngredientService.createMyIngredient(userDetails, createRequestDto)
+        );
+    }
+
+    @Test
+    @DisplayName("createMyIngredient - 요청정보의 재료 ID에 맞는 Ingredient가 존재하지 않을 경우")
+    void createMyIngredientFailByIngredient() {
+        // given
+        given(ingredientRepository.findById(anyInt())).willReturn(Optional.empty());
+
+        // when
+        assertThrows(
+            CustomException.class,
+            () -> myIngredientService.createMyIngredient(userDetails, createRequestDto)
+        );
+    }
+
+    @Test
+    @DisplayName("createMyIngredient 성공")
+    void createMyIngredientSuccess() {
+        // given
+        Ingredient ingredient = new Ingredient();
+        given(ingredientRepository.findById(anyInt())).willReturn(Optional.of(ingredient));
+
+        // when
+        myIngredientService.createMyIngredient(userDetails, createRequestDto);
+
+        // then
+        then(myIngredientRepository).should().save(any(MyIngredient.class));
+        then(myIngredientRepository).shouldHaveNoMoreInteractions();
+    }
+
+}

--- a/src/test/java/com/twoPotatoes/bobJoying/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/member/controller/AuthControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.graphql.test.tester.GraphQlTester;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.member.dto.TokenResponseDto;
 import com.twoPotatoes.bobJoying.member.entity.Member;
@@ -93,15 +94,14 @@ public class AuthControllerTest {
                 new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
             );
 
-        String message = "로그아웃이 완료되었습니다.";
-        given(authService.logout(any(Member.class))).willReturn(message);
+        ApiResponseDto apiResponseDto = new ApiResponseDto("로그아웃 성공");
+        given(authService.logout(any(Member.class))).willReturn(apiResponseDto);
 
         // When
         graphQlTester.documentName("auth")
             .operationName("logout")
             .execute()
-            .path("logout")
-            .entity(String.class)
-            .isEqualTo(message);
+            .path("logout.message")
+            .entity(String.class);
     }
 }

--- a/src/test/java/com/twoPotatoes/bobJoying/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/member/controller/AuthControllerTest.java
@@ -11,10 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.graphql.test.tester.GraphQlTester;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.twoPotatoes.bobJoying.common.config.GraphQlConfig;
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.member.dto.TokenResponseDto;
@@ -23,6 +25,7 @@ import com.twoPotatoes.bobJoying.member.entity.MemberRoleEnum;
 import com.twoPotatoes.bobJoying.member.service.AuthService;
 
 @GraphQlTest(AuthController.class)
+@Import(GraphQlConfig.class)
 public class AuthControllerTest {
     @Autowired
     private GraphQlTester graphQlTester;

--- a/src/test/java/com/twoPotatoes/bobJoying/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/member/controller/MemberControllerTest.java
@@ -8,11 +8,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.GraphQlTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.graphql.test.tester.GraphQlTester;
 
+import com.twoPotatoes.bobJoying.common.config.GraphQlConfig;
 import com.twoPotatoes.bobJoying.member.service.MemberService;
 
 @GraphQlTest(MemberController.class)
+@Import(GraphQlConfig.class)
 class MemberControllerTest {
     @Autowired
     private GraphQlTester graphQlTester;

--- a/src/test/resources/graphql-test/auth.graphql
+++ b/src/test/resources/graphql-test/auth.graphql
@@ -15,5 +15,7 @@ mutation reissueToken($input: TokenRequestDto!){
 }
 
 mutation logout {
-    logout
+    logout {
+        message
+    }
 }

--- a/src/test/resources/graphql-test/myIngredient.graphql
+++ b/src/test/resources/graphql-test/myIngredient.graphql
@@ -1,0 +1,5 @@
+mutation createMyIngredient($input: MyIngredientCreateRequestDto!){
+    createMyIngredient(myIngredientCreateRequestDto: $input){
+        message
+    }
+}


### PR DESCRIPTION
<!-- PR을 먼저 제출하고 내용을 작성하면 CI 기다리는 시간을 줄일 수 있어요! -->

# 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* close #5

<br>

# 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* 내 재료 등록 API 구현
* 메시지 상수화
* Ingredient Storage 변수 Enum으로 수정
* Logout API 결과 String -> ApiResponseDto 반환으로 수정
* CORS 허용
* H2 관련 코드 추가

- [x] 로컬에서 build test를 해보았나요?
- [x] 구현한 기능을 로컬에서 test해보았나요?
- [x] 도커에서 build test를 해보았나요?
- [x] 구현한 기능을 도커에서 test해보았나요?
- [x] 테스트 코드를 작성하였나요?

<br>

# 트러블 슈팅

## 1. DTO `@Builder` 적용 이슈

#### ⏩ Issue Description

ParentDto를 상속받는 ChildDto에 `@Builder` 패턴을 적용 시키려고 했는데 부모 필드를 생성할 수 없었습니다.
예를 들어 다음과 같이 Class가 있을 때,

```Java
@Getter
@Setter
@Builder
public abstract class Parent {
    private String name;
}

@Getter
@Setter
@Builder
public class Child extends Parent {
    private int age;
}    
```

제가 기대한 것은 이 방향이었는데

```java
Child child = Child.builder().age(10).name("아이").build();
```

상속받은 필드 `name`이 빌더 패턴에 적용되지 않고 다음만 가능했습니다.

```java
Child child = Child.builder().age(10).build();
```

<br>

#### ☑ Solution

찾아보니 `@Builder`는 상속받은 클래스의 필드까지는 생성할 수 없다고 합니다. 이 때 사용할 수 있는 것이 `@SuperBuilder` 입니다. 이 어노테이션을 부모 클래스와 자식 클래스에 모두 달아주면 자식 클래스에서 Builder 패턴으로 부모 클래스의 필드를 생성하는 것이 가능해집니다.

***Note*** : `@SuperBuilder` 어노테이션만을 사용하게 되면 GraphQL의 요청을 DTO에 맵핑시킬 때 `@Setter`를 사용하지 않고, `@Builder`를 사용하여 맵핑하게 되는데 이 때 문제가 발생합니다. 클래스가 제대로 초기화되지 않아서 발생하는 문제이며 이 때는 `@NoArgsConstructor` 어노테이션을 사용하여 클래스를 초기화하는 어노테이션을 추가하면 해결됩니다.

<br>

## 2. CORS 허용

#### ⏩ Issue Description

React 서버(3000 포트)에서 Springboot(8080 포트) 서버로 리소스를 요청하였는데 `CORS` 위반 에러가 발생하여 요청을 하지 못하는 에러가 발생했습니다. 이를 위해 `CORS`를 허용하는 코드를 작성하였으나 제대로 되지 않았습니다.

<br>

#### ☑ Solution

***Spring Security***를 사용하고 있는 ***Spring Mvc Application***의 경우 두 번에 걸쳐 `CORS` 체크를 한다고 합니다. 따라서 ***Spring Security, Spring Mvc***에서 `CORS` 허용을 두 번 해주어야 합니다.

<br>

## 3. Test code에서 GraphQL Schema Type `Date`를 인지 못하는 오류

#### ⏩ Issue Description

Controller Test code를 작성하는데 `Date` 필드를 인지하지 못하여 테스트 코드를 실행하지 못하는 오류가 발생했습니다.

<br>

#### ☑ Solution

`Date` 필드의 경우 기본적으로 ***GraphQL***에서 사용할 수 있는 필드가 아니라 따로 사용하겠다는 코드를 작성하여야 사용할 수 있는 필드입니다. 따라서 `GraphQlConfig` 클래스에서 다음과 같이 작성을 해주어야 합니다.

```java
@Configuration
public class GraphQlConfig {
    @Bean
    public RuntimeWiringConfigurer runtimeWiringConfigurer() {
        // GraphQL Schema에 Date 타입을 추가합니다.
        return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.Date);
    }
}
```

컨트롤러 테스트의 경우 제한된(명시된) Bean만 불러오게 되는데 `GraphQlConfig` Bean을 읽지 못해서 발생하는 오류였습니다. 테스트 코드 클래스 단에서 다음과 같이 `GraphQlConfig` 를 import해와서 해결하였습니다. 이 때, 다른 모든 컨트롤러 테스트에도 동일하게 `GraphQlConfig`를 import 해주어야 합니다.

```java
@GraphQlTest(MyIngredientController.class)
@Import(GraphQlConfig.class)
class MyIngredientControllerTest {
...
}
```