### PR TITLE
[feature] 내 식재료 관리 기능 - 여러 건 조회

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -31,14 +31,6 @@ jobs:
         with:
           redis version: "latest"
           redis password: "1234"
-
-      # Docker Redis Config 설정
-      - name: Docker Redis Config 설정
-        run: |
-          touch ./docker-redis.conf
-          echo "${{ secrets.REDIS_CONFIG }}" > ./docker-redis.conf
-        shell: bash
-
       # docker-compose.yml에서 필요한 환경변수 설정
       - name: 환경변수 설정
         run: |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 🙋‍♀️ 우리 서비스는요...
 
-1. 냉장고의 **식재료를 관리**해줘요! - 개발 중⏩
+1. 냉장고의 **식재료를 관리**해줘요! - 개발 완!✅
 2. 냉장고의 식재료로 할 수 있는 **레시피를 등록하고 관리**할 수 있어요! - 개발 중⏩
 3. 냉장고를 공유하는 그룹원에게 먹고 싶은 **레시피를 요청**할 수 있어요! - 개발 중⏩
 4. **식사 기록**이 가능하고 그룹원들의 오늘 식사 기록을 **피드**에서 확인할 수 있어요! - 개발 중⏩
@@ -191,18 +191,26 @@ JWT_SECRET_KEY: { BASE64로 encoding된 key }
 <summary>.env</summary>
   
 ```text
-POSTGRES_DB={Docker_DB_name}
-POSTGRES_USER={Docker_DB_username}
-POSTGRES_PASSWORD={Docker_DB_password}
+POSTGRES_DB={ Docker_DB_Name }
+POSTGRES_URL={ Docker_DB_URL }
+POSTGRES_USER={ Docker_DB_Username }
+POSTGRES_PASSWORD={ Docker_DB_password }
 
-POSTGRES_LOCAL_PORT=5433
+POSTGRES_LOCAL_PORT={ Docker_Postgres_Local_Port }
 POSTGRES_DOCKER_PORT=5432
 
-SPRING_LOCAL_PORT=8080
+SPRING_LOCAL_PORT={ Spring_Local_Port }
 SPRING_DOCKER_PORT=8080
 
-REDIS_LOCAL_PORT=6378
+SPRING_GRAPHQL_SCHEMA_LOCATIONS={ Spring_GraphQL_Schema_Locations }
+
+REDIS_LOCAL_PORT={ Redis_Local_Port }
 REDIS_DOCKER_PORT=6379
+
+REDIS_HOST=host.docker.internal
+REDIS_PASSWORD={ Redis_Password }
+
+JWT_SECRET_KEY={ Base64_Encoded_Secret_Key }
 ```
 
 </details>
@@ -233,21 +241,9 @@ spring.data.redis.host=localhost
 
 </details>
 
-##### 4️⃣ 프로젝트 가장 상위 폴더에 `docker-redis.conf` 파일을 생성합니다. (Docker Redis 환경 설정)
+##### 4️⃣ 로컬에서 project를 build해서 `jar`파일을 생성합니다.
 
-<details>
-<summary>docker-redis.conf</summary>
-
-```text
-bind 0.0.0.0
-requirepass {Docker_Redis_Password}
-```
-
-</details>
-
-##### 5️⃣ 로컬에서 project를 build해서 `jar`파일을 생성합니다.
-
-##### 6️⃣ 터미널에서 docker compose 실행 명령어를 입력하여 프로젝트를 build합니다.
+##### 5️⃣ 터미널에서 docker compose 실행 명령어를 입력하여 프로젝트를 build합니다.
 
 ```shell
 docker-compose -f docker-compose-dev.yml up -d

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -35,8 +35,8 @@ services:
       - ${REDIS_LOCAL_PORT}:${REDIS_DOCKER_PORT}
     volumes:
       - bobJoyingRedisVolume:/data
-      - ./docker-redis.conf:/usr/local/etc/redis/redis.conf
-    command: redis-server /usr/local/etc/redis/redis.conf
+    command: >
+      --bind 0.0.0.0 --requirepass ${REDIS_PASSWORD}
 
 volumes:
   bobJoyingDBVolume:

--- a/src/main/java/com/twoPotatoes/bobJoying/BobJoyingApplication.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/BobJoyingApplication.java
@@ -2,7 +2,6 @@ package com.twoPotatoes.bobJoying;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
 @SpringBootApplication
 public class BobJoyingApplication {

--- a/src/main/java/com/twoPotatoes/bobJoying/common/constants/ErrorMsgConstants.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/constants/ErrorMsgConstants.java
@@ -11,4 +11,6 @@ public class ErrorMsgConstants {
     public static final String INVALID_EXPIRATION_DATE = "소비 기한은 오늘 또는 등록 날짜 이후의 날짜를 입력해야 합니다.";
     public static final String INVALID_UNIT = "단위는 10자를 초과할 수 없습니다.";
     public static final String TOO_LONG_EXPIRATION_DATE = "소비기한이 허용된 범위를 초과했습니다.";
+    public static final String INVALID_SORTBY = "잘못된 정렬기준입니다.";
+    public static final String NO_MORE_DATA = "더 이상 데이터가 존재하지 않습니다.";
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/common/constants/MyIngredientConstants.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/constants/MyIngredientConstants.java
@@ -1,16 +1,35 @@
 package com.twoPotatoes.bobJoying.common.constants;
 
 public class MyIngredientConstants {
+    // Message
     // Validation
     public static final String INVALID_UNIT = "단위는 10자를 넘어갈 수 없습니다.";
     public static final String INVALID_ID = "id는 1이상이어야 합니다.";
 
+    // Response Message
+    public static final String DELETE_MY_INGREDIENT_SUCCESS = "재료 삭제가 완료되었습니다.";
+    public static final String CREATE_MY_INGREDIENT_SUCCESS = "재료 등록이 완료되었습니다.";
+
+    // Enum
     // StorageEnum
     public static final String FRIDGE = "냉장";
     public static final String FREEZER = "냉동";
     public static final String ROOM_TEMPERATURE = "실온";
 
-    // Response Message
-    public static final String CREATE_MY_INGREDIENT_SUCCESS = "재료 등록이 완료되었습니다.";
-    public static final String DELETE_MY_INGREDIENT_SUCCESS = "재료 삭제가 완료되었습니다.";
+    // CategoryEnum
+    public static final String FRUIT = "과일";
+    public static final String VEGETABLE = "채소";
+    public static final String MEAT = "고기";
+    public static final String MARINE_PRODUCT = "수산물";
+    public static final String DAIRY_PRODUCT = "유제품";
+    public static final String PLATE = "요리";
+    public static final String DRINK = "음료";
+    public static final String ALCOHOL = "주류";
+    public static final String SEASONING = "조미료";
+    public static final String SPICE = "향신료";
+    public static final String BREAD = "빵류";
+    public static final String DESSERT = "디저트";
+    public static final String NUT = "견과류";
+    public static final String GRAIN = "곡류";
+    public static final String ETC = "기타";
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/common/dto/PageRequestDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/dto/PageRequestDto.java
@@ -1,0 +1,20 @@
+package com.twoPotatoes.bobJoying.common.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public class PageRequestDto {
+    @Min(value = 1, message = "페이지는 1 이상이어야 합니다.")
+    private int page;
+    @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+    private int size;
+    private String sortBy;
+    private Boolean isAsc;
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/common/entity/Timestamped.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/entity/Timestamped.java
@@ -2,7 +2,6 @@ package com.twoPotatoes.bobJoying.common.entity;
 
 import java.time.ZonedDateTime;
 
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;

--- a/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/common/exception/CustomErrorCode.java
@@ -15,7 +15,9 @@ public enum CustomErrorCode {
     INVALID_EXPIRATION_DATE(CustomErrorType.BAD_REQUEST, ErrorMsgConstants.INVALID_EXPIRATION_DATE),
     INVALID_UNIT(CustomErrorType.BAD_REQUEST, ErrorMsgConstants.INVALID_UNIT),
     MY_INGREDIENT_NOT_FOUND(CustomErrorType.NOT_FOUND, ErrorMsgConstants.INGREDIENT_NOT_FOUND),
-    TOO_LONG_EXPIRATION_DATE(CustomErrorType.BAD_REQUEST, ErrorMsgConstants.TOO_LONG_EXPIRATION_DATE);
+    TOO_LONG_EXPIRATION_DATE(CustomErrorType.BAD_REQUEST, ErrorMsgConstants.TOO_LONG_EXPIRATION_DATE),
+    INVALID_SORTBY(CustomErrorType.BAD_REQUEST, ErrorMsgConstants.INVALID_SORTBY),
+    NO_MORE_DATA(CustomErrorType.NOT_FOUND, ErrorMsgConstants.NO_MORE_DATA);
 
     private final CustomErrorType errorType;
     private final String message;

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientController.java
@@ -1,5 +1,7 @@
 package com.twoPotatoes.bobJoying.ingredient.controller;
 
+import java.util.List;
+
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
@@ -8,8 +10,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientPageRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientUpdateRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.service.MyIngredientService;
@@ -53,4 +57,29 @@ public class MyIngredientController {
         @Argument int myIngredientId) {
         return myIngredientService.getMyIngredient(userDetails, myIngredientId);
     }
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    public List<MyIngredientResponseDto> getMyIngredientsByCategory(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Argument @Valid MyIngredientPageRequestDto myIngredientPageRequestDto) {
+        return myIngredientService.getMyIngredientsByCategory(userDetails, myIngredientPageRequestDto);
+    }
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    public List<MyIngredientResponseDto> getMyIngredientsByStorage(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Argument @Valid MyIngredientPageRequestDto myIngredientPageRequestDto) {
+        return myIngredientService.getMyIngredientsByStorage(userDetails, myIngredientPageRequestDto);
+    }
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    public List<MyIngredientResponseDto> getMyIngredients(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Argument @Valid PageRequestDto pageRequestDto) {
+        return myIngredientService.getMyIngredients(userDetails, pageRequestDto);
+    }
+
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientBaseDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientBaseDto.java
@@ -16,7 +16,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 public abstract class MyIngredientBaseDto {
-    private float quantity;
+    private Float quantity;
     @Size(max = 10, message = MyIngredientConstants.INVALID_UNIT)
     private String unit;
     private LocalDate storageDate;

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientCreateRequestDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientCreateRequestDto.java
@@ -14,5 +14,5 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class MyIngredientCreateRequestDto extends MyIngredientBaseDto {
     @Min(value = 1, message = MyIngredientConstants.INVALID_ID)
-    private int ingredientId;
+    private Integer ingredientId;
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientPageRequestDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientPageRequestDto.java
@@ -1,0 +1,28 @@
+package com.twoPotatoes.bobJoying.ingredient.dto;
+
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.entity.CategoryEnum;
+import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public class MyIngredientPageRequestDto extends PageRequestDto {
+    private CategoryEnum categoryEnum;
+    private StorageEnum storageEnum;
+
+    public PageRequestDto toPageRequestDto() {
+        return PageRequestDto.builder()
+            .page(this.getPage())
+            .size(this.getSize())
+            .sortBy(this.getSortBy())
+            .isAsc(this.getIsAsc())
+            .build();
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientResponseDto.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/dto/MyIngredientResponseDto.java
@@ -8,6 +8,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 public class MyIngredientResponseDto extends MyIngredientBaseDto {
-    private int myIngredientId;
+    private String name;
+    private Integer myIngredientId;
     private Integer dDay;
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/CategoryEnum.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/CategoryEnum.java
@@ -1,0 +1,30 @@
+package com.twoPotatoes.bobJoying.ingredient.entity;
+
+import com.twoPotatoes.bobJoying.common.constants.MyIngredientConstants;
+
+import lombok.Getter;
+
+@Getter
+public enum CategoryEnum {
+    FRUIT(MyIngredientConstants.FRUIT),
+    VEGETABLE(MyIngredientConstants.VEGETABLE),
+    MEAT(MyIngredientConstants.MEAT),
+    MARINE_PRODUCT(MyIngredientConstants.MARINE_PRODUCT),
+    DAIRY_PRODUCT(MyIngredientConstants.DAIRY_PRODUCT),
+    PLATE(MyIngredientConstants.PLATE),
+    DRINK(MyIngredientConstants.DRINK),
+    ALCOHOL(MyIngredientConstants.ALCOHOL),
+    SEASONING(MyIngredientConstants.SEASONING),
+    SPICE(MyIngredientConstants.SPICE),
+    BREAD(MyIngredientConstants.BREAD),
+    DESSERT(MyIngredientConstants.DESSERT),
+    NUT(MyIngredientConstants.NUT),
+    GRAIN(MyIngredientConstants.GRAIN),
+    ETC(MyIngredientConstants.ETC);
+
+    private final String category;
+
+    CategoryEnum(String category) {
+        this.category = category;
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/Ingredient.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/Ingredient.java
@@ -28,14 +28,15 @@ public class Ingredient {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @Enumerated(value = EnumType.STRING)
     @Column(nullable = false, length = 10)
-    private String category;
+    private CategoryEnum category;
 
     @Column(nullable = false)
     private String name;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 10)
     private StorageEnum storage;
 
     @Column(nullable = false, length = 10)
@@ -49,5 +50,4 @@ public class Ingredient {
     @OneToMany(mappedBy = "ingredient")
     @Builder.Default
     private List<MyIngredient> myIngredientList = new ArrayList<>();
-
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/MyIngredient.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/MyIngredient.java
@@ -1,7 +1,6 @@
 package com.twoPotatoes.bobJoying.ingredient.entity;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.temporal.ChronoUnit;
 
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientResponseDto;

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/MyIngredient.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/entity/MyIngredient.java
@@ -70,6 +70,7 @@ public class MyIngredient {
         return MyIngredientResponseDto.builder()
             .myIngredientId(id)
             .dDay(dday)
+            .name(ingredient.getName())
             .quantity(quantity)
             .unit(unit)
             .storageDate(storageDate)

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/MyIngredientRepository.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/MyIngredientRepository.java
@@ -1,8 +1,10 @@
 package com.twoPotatoes.bobJoying.ingredient.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.twoPotatoes.bobJoying.ingredient.entity.MyIngredient;
 
-public interface MyIngredientRepository extends JpaRepository<MyIngredient, Integer> {
+@Repository
+public interface MyIngredientRepository extends JpaRepository<MyIngredient, Integer>, MyIngredientRepositoryCustom {
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/MyIngredientRepositoryCustom.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/MyIngredientRepositoryCustom.java
@@ -1,0 +1,25 @@
+package com.twoPotatoes.bobJoying.ingredient.repository;
+
+import java.util.List;
+
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.entity.CategoryEnum;
+import com.twoPotatoes.bobJoying.ingredient.entity.MyIngredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
+
+public interface MyIngredientRepositoryCustom {
+    // 내 재료 Storage 별 조회
+    List<MyIngredient> findAllByMemberAndStorage(
+        int memberId, PageRequestDto pageDto, StorageEnum storageEnum
+    );
+
+    // 내 재료 Category 별 조회
+    List<MyIngredient> findAllByMemberAndCategory(
+        int memberId, PageRequestDto pageDto, CategoryEnum categoryEnum
+    );
+
+    // 내 재료 모두 조회
+    List<MyIngredient> findAllByMember(
+        int memberId, PageRequestDto pageDto
+    );
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/MyIngredientRepositoryImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/MyIngredientRepositoryImpl.java
@@ -1,0 +1,104 @@
+package com.twoPotatoes.bobJoying.ingredient.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
+import com.twoPotatoes.bobJoying.common.exception.CustomErrorCode;
+import com.twoPotatoes.bobJoying.common.exception.CustomException;
+import com.twoPotatoes.bobJoying.ingredient.entity.CategoryEnum;
+import com.twoPotatoes.bobJoying.ingredient.entity.MyIngredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.QIngredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.QMyIngredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MyIngredientRepositoryImpl implements MyIngredientRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+    QMyIngredient myIngredient = QMyIngredient.myIngredient;
+    QIngredient ingredient = QIngredient.ingredient;
+
+    @Override
+    public List<MyIngredient> findAllByMemberAndStorage(
+        int memberId, PageRequestDto pageDto, StorageEnum storageEnum) {
+
+        OrderSpecifier<?> orderSpecifier = getMyIngredientOrderSpecifier(pageDto);
+
+        return jpaQueryFactory.selectFrom(myIngredient)
+            .join(myIngredient.ingredient, ingredient).fetchJoin()
+            .where(myIngredient.member.id.eq(memberId))
+            .where(myIngredient.storage.eq(storageEnum))
+            .orderBy(orderSpecifier)
+            .offset((long)pageDto.getPage() * pageDto.getSize())
+            .limit(pageDto.getSize())
+            .fetch();
+    }
+
+    @Override
+    public List<MyIngredient> findAllByMemberAndCategory(
+        int memberId, PageRequestDto pageDto, CategoryEnum categoryEnum) {
+
+        OrderSpecifier<?> orderSpecifier = getMyIngredientOrderSpecifier(pageDto);
+
+        return jpaQueryFactory.selectFrom(myIngredient)
+            .join(myIngredient.ingredient, ingredient).fetchJoin()
+            .where(myIngredient.member.id.eq(memberId))
+            .where(myIngredient.ingredient.category.eq(categoryEnum))
+            .orderBy(orderSpecifier)
+            .offset((long)pageDto.getPage() * pageDto.getSize())
+            .limit(pageDto.getSize())
+            .fetch();
+    }
+
+    @Override
+    public List<MyIngredient> findAllByMember(
+        int memberId, PageRequestDto pageDto) {
+
+        OrderSpecifier<?> orderSpecifier = getMyIngredientOrderSpecifier(pageDto);
+
+        return jpaQueryFactory.selectFrom(myIngredient)
+            .join(myIngredient.ingredient, ingredient).fetchJoin()
+            .where(myIngredient.member.id.eq(memberId))
+            .orderBy(orderSpecifier)
+            .offset((long)pageDto.getPage() * pageDto.getSize())
+            .limit(pageDto.getSize())
+            .fetch();
+    }
+
+    private OrderSpecifier<?> getMyIngredientOrderSpecifier(PageRequestDto pageDto) {
+        boolean isAsc = pageDto.getIsAsc();
+        OrderSpecifier<?> orderSpecifier = null;
+        switch (pageDto.getSortBy()) {
+            case "name":
+                if (isAsc) {
+                    orderSpecifier = myIngredient.ingredient.name.asc();
+                } else {
+                    orderSpecifier = myIngredient.ingredient.name.desc();
+                }
+                break;
+            case "expirationDate":
+                if (isAsc) {
+                    orderSpecifier = myIngredient.expirationDate.asc().nullsLast();
+                } else {
+                    orderSpecifier = myIngredient.expirationDate.desc().nullsLast();
+                }
+                break;
+            case "id":
+                if (isAsc) {
+                    orderSpecifier = myIngredient.id.asc();
+                } else {
+                    orderSpecifier = myIngredient.id.desc();
+                }
+                break;
+            default:
+                throw new CustomException(CustomErrorCode.INVALID_SORTBY);
+        }
+        return orderSpecifier;
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientService.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientService.java
@@ -1,8 +1,12 @@
 package com.twoPotatoes.bobJoying.ingredient.service;
 
+import java.util.List;
+
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientPageRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientUpdateRequestDto;
 
@@ -42,4 +46,40 @@ public interface MyIngredientService {
      * @return 해당 식재료 정보
      */
     MyIngredientResponseDto getMyIngredient(UserDetailsImpl userDetails, int myIngredientId);
+
+    /**
+     * 등록한 내 모든 식재료를 페이징 조건에 맞게 조회합니다.
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @param pageRequestDto 페이징에 필요한 정보
+     * @return 내 모든 식재료
+     */
+    List<MyIngredientResponseDto> getMyIngredients(
+        UserDetailsImpl userDetails,
+        PageRequestDto pageRequestDto
+    );
+
+    /**
+     * 등록한 내 모든 식재료를 카테고리에 맞게 조회합니다.
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @param myIngredientPageRequestDto 카테고리, 페이징 정보
+     * @return 카테고리에 알맞는 식재료
+     */
+    List<MyIngredientResponseDto> getMyIngredientsByCategory(
+        UserDetailsImpl userDetails,
+        MyIngredientPageRequestDto myIngredientPageRequestDto
+    );
+
+    /**
+     * 등록한 내 모든 식재료를 Storage에 맞게 조회합니다.
+     *
+     * @param userDetails 인증된 사용자 정보
+     * @param myIngredientPageRequestDto Storage, 페이징 정보
+     * @return Storage에 알맞는 식재료
+     */
+    List<MyIngredientResponseDto> getMyIngredientsByStorage(
+        UserDetailsImpl userDetails,
+        MyIngredientPageRequestDto myIngredientPageRequestDto
+    );
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/MyIngredientServiceImpl.java
@@ -1,16 +1,20 @@
 package com.twoPotatoes.bobJoying.ingredient.service;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.twoPotatoes.bobJoying.common.constants.MyIngredientConstants;
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
 import com.twoPotatoes.bobJoying.common.exception.CustomErrorCode;
 import com.twoPotatoes.bobJoying.common.exception.CustomException;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientPageRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientUpdateRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.entity.Ingredient;
@@ -69,6 +73,58 @@ public class MyIngredientServiceImpl implements MyIngredientService {
         MyIngredient target = findMyIngredient(myIngredientId);
         checkAuthority(userDetails, target.getMember());
         return target.toDto();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyIngredientResponseDto> getMyIngredients(UserDetailsImpl userDetails, PageRequestDto pageDto) {
+        pageDto.setPage(pageDto.getPage() - 1);
+        List<MyIngredient> myIngredientList = myIngredientRepository.findAllByMember(
+            userDetails.getMember().getId(),
+            pageDto
+        );
+        if (myIngredientList.isEmpty()) {
+            throw new CustomException(CustomErrorCode.NO_MORE_DATA);
+        }
+        return toMyIngredientResponseDtoList(myIngredientList);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyIngredientResponseDto> getMyIngredientsByCategory(
+        UserDetailsImpl userDetails,
+        MyIngredientPageRequestDto requestDto) {
+        requestDto.setPage(requestDto.getPage() - 1);
+        List<MyIngredient> myIngredientList = myIngredientRepository.findAllByMemberAndCategory(
+            userDetails.getMember().getId(),
+            requestDto.toPageRequestDto(),
+            requestDto.getCategoryEnum()
+        );
+        if (myIngredientList.isEmpty()) {
+            throw new CustomException(CustomErrorCode.NO_MORE_DATA);
+        }
+        return toMyIngredientResponseDtoList(myIngredientList);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyIngredientResponseDto> getMyIngredientsByStorage(
+        UserDetailsImpl userDetails,
+        MyIngredientPageRequestDto requestDto) {
+        requestDto.setPage(requestDto.getPage() - 1);
+        List<MyIngredient> myIngredientList = myIngredientRepository.findAllByMemberAndStorage(
+            userDetails.getMember().getId(),
+            requestDto.toPageRequestDto(),
+            requestDto.getStorageEnum()
+        );
+        if (myIngredientList.isEmpty()) {
+            throw new CustomException(CustomErrorCode.NO_MORE_DATA);
+        }
+        return toMyIngredientResponseDtoList(myIngredientList);
+    }
+
+    private List<MyIngredientResponseDto> toMyIngredientResponseDtoList(List<MyIngredient> myIngredientList) {
+        return myIngredientList.stream().map(MyIngredient::toDto).collect(Collectors.toList());
     }
 
     private static void checkAuthority(UserDetailsImpl userDetails, Member member) {

--- a/src/main/resources/graphql/ingredient/ingredientDto.graphqls
+++ b/src/main/resources/graphql/ingredient/ingredientDto.graphqls
@@ -4,6 +4,24 @@ enum StorageEnum {
     ROOM_TEMPERATURE
 }
 
+enum CategoryEnum {
+    FRUIT
+    VEGETABLE
+    MEAT
+    MARINE_PRODUCT
+    DAIRY_PRODUCT
+    PLATE
+    DRINK
+    ALCOHOL
+    SEASONING
+    SPICE
+    BREAD
+    DESSERT
+    NUT
+    GRAIN
+    ETC
+}
+
 input MyIngredientCreateRequestDto {
     quantity: Float!
     unit: String!
@@ -24,10 +42,27 @@ input MyIngredientUpdateRequestDto {
 
 type MyIngredientResponseDto {
     myIngredientId: ID!
+    name: String!
     quantity: Float!
     unit: String!
     storageDate: Date
     expirationDate: Date
     dDay: Int
     storage: StorageEnum!
+}
+
+input MyIngredientPageRequestDto {
+    categoryEnum: CategoryEnum
+    storageEnum: StorageEnum
+    page: Int
+    size: Int
+    sortBy: String
+    isAsc: Boolean
+}
+
+input PageRequestDto {
+    page: Int
+    size: Int
+    sortBy: String
+    isAsc: Boolean
 }

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -1,3 +1,7 @@
 type Query {
+    # MyIngredient
     getMyIngredient(myIngredientId: ID!): MyIngredientResponseDto
+    getMyIngredientsByCategory(myIngredientPageRequestDto: MyIngredientPageRequestDto!): [MyIngredientResponseDto]
+    getMyIngredientsByStorage(myIngredientPageRequestDto: MyIngredientPageRequestDto!): [MyIngredientResponseDto]
+    getMyIngredients(pageRequestDto: PageRequestDto!): [MyIngredientResponseDto]
 }

--- a/src/test/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientControllerTest.java
+++ b/src/test/java/com/twoPotatoes/bobJoying/ingredient/controller/MyIngredientControllerTest.java
@@ -3,7 +3,9 @@ package com.twoPotatoes.bobJoying.ingredient.controller;
 import static com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,8 +21,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.twoPotatoes.bobJoying.common.config.GraphQlConfig;
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
 import com.twoPotatoes.bobJoying.common.security.UserDetailsImpl;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientCreateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientPageRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientUpdateRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.service.MyIngredientService;
@@ -134,6 +138,57 @@ class MyIngredientControllerTest {
         graphQlTester.documentName("myIngredient")
             .variable("input", 1)
             .operationName("getMyIngredient")
+            .execute();
+    }
+
+    @Test
+    @DisplayName("MyIngredientController Test - getMyIngredientsByCategory")
+    void getMyIngredientsByCategory() {
+        // given
+        MyIngredientPageRequestDto myIngredientPageRequestDto = new MyIngredientPageRequestDto();
+        List<MyIngredientResponseDto> myIngredientResponseDtoList = new ArrayList<>();
+
+        given(myIngredientService.getMyIngredientsByCategory(userDetails, myIngredientPageRequestDto))
+            .willReturn(myIngredientResponseDtoList);
+
+        // when
+        graphQlTester.documentName("myIngredient")
+            .variable("input", myIngredientPageRequestDto)
+            .operationName("getMyIngredientsByCategory")
+            .execute();
+    }
+
+    @Test
+    @DisplayName("MyIngredientController Test - getMyIngredientsByStorage")
+    void getMyIngredientsByStorage() {
+        // given
+        MyIngredientPageRequestDto myIngredientPageRequestDto = new MyIngredientPageRequestDto();
+        List<MyIngredientResponseDto> myIngredientResponseDtoList = new ArrayList<>();
+
+        given(myIngredientService.getMyIngredientsByStorage(userDetails, myIngredientPageRequestDto))
+            .willReturn(myIngredientResponseDtoList);
+
+        // when
+        graphQlTester.documentName("myIngredient")
+            .variable("input", myIngredientPageRequestDto)
+            .operationName("getMyIngredientsByStorage")
+            .execute();
+    }
+
+    @Test
+    @DisplayName("MyIngredientController Test - getMyIngredients")
+    void getMyIngredients() {
+        // given
+        PageRequestDto pageRequestDto = new PageRequestDto();
+        List<MyIngredientResponseDto> myIngredientResponseDtoList = new ArrayList<>();
+
+        given(myIngredientService.getMyIngredients(userDetails, pageRequestDto))
+            .willReturn(myIngredientResponseDtoList);
+
+        // when
+        graphQlTester.documentName("myIngredient")
+            .variable("input", pageRequestDto)
+            .operationName("getMyIngredients")
             .execute();
     }
 }

--- a/src/test/resources/graphql-test/myIngredient.graphql
+++ b/src/test/resources/graphql-test/myIngredient.graphql
@@ -33,3 +33,39 @@ query getMyIngredient($input: ID!) {
         storage
     }
 }
+
+query getMyIngredientsByCategory($input: MyIngredientPageRequestDto!){
+    getMyIngredientsByCategory(myIngredientPageRequestDto: $input){
+        myIngredientId
+        quantity
+        unit
+        storageDate
+        expirationDate
+        dDay
+        storage
+    }
+}
+
+query getMyIngredientsByStorage($input: MyIngredientPageRequestDto!){
+    getMyIngredientsByCategory(myIngredientPageRequestDto: $input){
+        myIngredientId
+        quantity
+        unit
+        storageDate
+        expirationDate
+        dDay
+        storage
+    }
+}
+
+query getMyIngredients($input: PageRequestDto!){
+    getMyIngredients(pageRequestDto: $input){
+        myIngredientId
+        quantity
+        unit
+        storageDate
+        expirationDate
+        dDay
+        storage
+    }
+}


### PR DESCRIPTION
<!-- PR을 먼저 제출하고 내용을 작성하면 CI 기다리는 시간을 줄일 수 있어요! -->

# 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* close #56 

<br>

# 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* Ingredient - category -> Enum Type으로 변경
* DTO 필드 -> Wrapper Type으로 수정
* Docker-compose Script - Redis 설정 수정
* README - 기능 개발 여부, Docker compose Build 부분 수정
* 내 식재료 관리 기능 - 여러 건 조회 기능 구현
  * storage 별 조회
  * category 별 조회
  * 전체 조회
  * 페이지네이션 - page, size(페이지 당 데이터 개수), 오름차순 여부, 정렬기준
* 내 식재료 관리 기능 테스트 코드 작성

- [x] 로컬에서 build test를 해보았나요?
- [x] 구현한 기능을 로컬에서 test해보았나요?
- [x] 도커에서 build test를 해보았나요?
- [x] 구현한 기능을 도커에서 test해보았나요?
- [x] 테스트 코드를 작성하였나요?

✅ 테스트 내용이 너무 길어 노션 페이지로 대체합니다. -> [노션 페이지 링크](https://two-potatoes.notion.site/693cf045fffb4b568b606675cc07982d?pvs=4)

<br>

# 트러블 슈팅 & 기타

* GraphQL에서 `boolean` 타입을 body에 담아 보낼 때 이것을 맵핑하지 못하는 이슈가 있었습니다. 왜 그런지 아직 밝혀내지는 못하였지만 DTO 필드 타입을 `boolean` 이 아니라 `Boolean`으로 수정하니 해결되었습니다. 아마 맵핑할 때 타입까지 체크하는 게 아닐까 하는 예상.
* Storage, Category, 전체 조회 기능을 한 메서드로 구현할까 하다가 너무 복잡해져서 세 개의 메서드로 나누게 되었습니다.
* Docker 에 들어가는 설정 중에 중요한 변수를 .env에 환경변수로 설정해주었습니다.