### PR TITLE
[feature] 관리자 식재료 여러 건 조회 API 구현 [WIP]

### DIFF
--- a/Dockerfile-postgres
+++ b/Dockerfile-postgres
@@ -1,0 +1,11 @@
+FROM postgres
+
+# 올바른 경로로 심볼릭 링크 생성 및 locale 설정
+RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+    echo 'ko_KR.UTF-8 UTF-8' >> /etc/locale.gen && \
+    locale-gen
+
+# 환경 변수 설정
+ENV LANG=ko_KR.UTF-8 \
+    LC_COLLATE=ko_KR.UTF-8 \
+    POSTGRES_INITDB_ARGS="--data-checksums"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,8 +2,10 @@ version: "3"
 services:
   postgres:
     container_name: postgres
+    build:
+      context: .
+      dockerfile: Dockerfile-postgres
     env_file: ./.env
-    image: postgres
     volumes:
       - bobJoyingDBVolume:/var/lib/postgresql/data
     environment:

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/controller/IngredientController.java
@@ -1,5 +1,7 @@
 package com.twoPotatoes.bobJoying.ingredient.controller;
 
+import java.util.List;
+
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
@@ -11,6 +13,7 @@ import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientCreateRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientUpdateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientPageRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.service.IngredientService;
 
 import jakarta.validation.Valid;
@@ -45,5 +48,12 @@ public class IngredientController {
     @Secured("ROLE_ADMIN")
     public ApiResponseDto deleteIngredient(@Argument int ingredientId) {
         return ingredientService.deleteIngredient(ingredientId);
+    }
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    public List<IngredientResponseDto> getIngredientsByCategory(
+        @Argument @Valid MyIngredientPageRequestDto myIngredientPageRequestDto) {
+        return ingredientService.getIngredientsByCategory(myIngredientPageRequestDto);
     }
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/IngredientRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 import com.twoPotatoes.bobJoying.ingredient.entity.Ingredient;
 
 @Repository
-public interface IngredientRepository extends JpaRepository<Ingredient, Integer> {
+public interface IngredientRepository extends JpaRepository<Ingredient, Integer>, IngredientRepositoryCustom {
     Optional<Ingredient> findByName(String name);
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/IngredientRepositoryCustom.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/IngredientRepositoryCustom.java
@@ -1,0 +1,25 @@
+package com.twoPotatoes.bobJoying.ingredient.repository;
+
+import java.util.List;
+
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.entity.CategoryEnum;
+import com.twoPotatoes.bobJoying.ingredient.entity.Ingredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
+
+public interface IngredientRepositoryCustom {
+    // 식재료 Category 별 조회
+    List<Ingredient> findAllByCategory(
+        PageRequestDto pageDto, CategoryEnum category
+    );
+
+    // 식재료 Storage 별 조회
+    List<Ingredient> findAllByStorage(
+        PageRequestDto pageDto, StorageEnum storage
+    );
+
+    // 식재료 모두 조회
+    List<Ingredient> findAll(
+        PageRequestDto pageDto
+    );
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/IngredientRepositoryImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/repository/IngredientRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.twoPotatoes.bobJoying.ingredient.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twoPotatoes.bobJoying.common.dto.PageRequestDto;
+import com.twoPotatoes.bobJoying.common.exception.CustomErrorCode;
+import com.twoPotatoes.bobJoying.common.exception.CustomException;
+import com.twoPotatoes.bobJoying.ingredient.entity.CategoryEnum;
+import com.twoPotatoes.bobJoying.ingredient.entity.Ingredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.QIngredient;
+import com.twoPotatoes.bobJoying.ingredient.entity.StorageEnum;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class IngredientRepositoryImpl implements IngredientRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+    QIngredient ingredient = QIngredient.ingredient;
+
+    @Override
+    public List<Ingredient> findAllByCategory(PageRequestDto pageDto, CategoryEnum category) {
+        OrderSpecifier<?> orderSpecifier = getIngredientOrderSpecifier(pageDto);
+        return jpaQueryFactory.selectFrom(ingredient)
+            .where(ingredient.category.eq(category))
+            .orderBy(orderSpecifier)
+            .offset((long)pageDto.getPage() * pageDto.getSize())
+            .limit(pageDto.getSize())
+            .fetch();
+    }
+
+    @Override
+    public List<Ingredient> findAllByStorage(PageRequestDto pageDto, StorageEnum storage) {
+        return List.of();
+    }
+
+    @Override
+    public List<Ingredient> findAll(PageRequestDto pageDto) {
+        return List.of();
+    }
+
+    private OrderSpecifier<?> getIngredientOrderSpecifier(PageRequestDto pageDto) {
+        boolean isAsc = pageDto.getIsAsc();
+        OrderSpecifier<?> orderSpecifier = null;
+        switch (pageDto.getSortBy()) {
+            case "name":
+                if (isAsc) {
+                    orderSpecifier = ingredient.name.asc();
+                } else {
+                    orderSpecifier = ingredient.name.desc();
+                }
+                break;
+            case "id":
+                if (isAsc) {
+                    orderSpecifier = ingredient.id.asc();
+                } else {
+                    orderSpecifier = ingredient.id.desc();
+                }
+                break;
+            default:
+                throw new CustomException(CustomErrorCode.INVALID_SORTBY);
+        }
+        return orderSpecifier;
+    }
+}

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/IngredientService.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/IngredientService.java
@@ -1,9 +1,12 @@
 package com.twoPotatoes.bobJoying.ingredient.service;
 
+import java.util.List;
+
 import com.twoPotatoes.bobJoying.common.dto.ApiResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientCreateRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientUpdateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientPageRequestDto;
 
 public interface IngredientService {
     /**
@@ -36,4 +39,12 @@ public interface IngredientService {
      * @return 식재료 삭제 성공 메시지
      */
     ApiResponseDto deleteIngredient(int ingredientId);
+
+    /**
+     * 모든 식재료를 카테고리에 맞게 조회합니다.
+     *
+     * @param requestDto 카테고리, 페이징 정보
+     * @return 카테고리에 알맞는 식재료 리스트
+     */
+    List<IngredientResponseDto> getIngredientsByCategory(MyIngredientPageRequestDto requestDto);
 }

--- a/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/IngredientServiceImpl.java
+++ b/src/main/java/com/twoPotatoes/bobJoying/ingredient/service/IngredientServiceImpl.java
@@ -1,5 +1,8 @@
 package com.twoPotatoes.bobJoying.ingredient.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +13,7 @@ import com.twoPotatoes.bobJoying.common.exception.CustomException;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientCreateRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientResponseDto;
 import com.twoPotatoes.bobJoying.ingredient.dto.IngredientUpdateRequestDto;
+import com.twoPotatoes.bobJoying.ingredient.dto.MyIngredientPageRequestDto;
 import com.twoPotatoes.bobJoying.ingredient.entity.Ingredient;
 import com.twoPotatoes.bobJoying.ingredient.repository.IngredientRepository;
 
@@ -47,6 +51,19 @@ public class IngredientServiceImpl implements IngredientService {
         findIngredient(ingredientId);
         ingredientRepository.deleteById(ingredientId);
         return new ApiResponseDto(MyIngredientConstants.DELETE_MY_INGREDIENT_SUCCESS);
+    }
+
+    @Override
+    public List<IngredientResponseDto> getIngredientsByCategory(MyIngredientPageRequestDto requestDto) {
+        requestDto.setPage(requestDto.getPage() - 1);
+        List<Ingredient> ingredientList = ingredientRepository.findAllByCategory(
+            requestDto.toPageRequestDto(),
+            requestDto.getCategoryEnum()
+        );
+        if (ingredientList.isEmpty()) {
+            throw new CustomException(CustomErrorCode.NO_MORE_DATA);
+        }
+        return ingredientList.stream().map(Ingredient::toIngredientResponseDto).toList();
     }
 
     public Ingredient findIngredient(int id) {

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -7,4 +7,5 @@ type Query {
 
     # Ingredient
     getIngredient(ingredientId: ID!): IngredientResponseDto
+    getIngredientsByCategory(myIngredientPageRequestDto: MyIngredientPageRequestDto!): [IngredientResponseDto]
 }


### PR DESCRIPTION
<!-- PR을 먼저 제출하고 내용을 작성하면 CI 기다리는 시간을 줄일 수 있어요! -->

# 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* close #60 

<br>

# 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* 관리자 식재료 여러 건 조회 API 구현

- [ ] 로컬에서 build test를 해보았나요?
- [ ] 구현한 기능을 로컬에서 test해보았나요?
- [ ] 도커에서 build test를 해보았나요?
- [ ] 구현한 기능을 도커에서 test해보았나요?
- [ ] 테스트 코드를 작성하였나요?

<br>

# Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  

* check list에 있는 옵션 모두

<br>

# 트러블 슈팅

`Docker` `Postgres` 기본 이미지로 `Postgres`를 컨테이너에 올리면 기본 정렬 옵션이 `en_US.utf8`로 되어 있어 정렬하는 경우 다음과 같은 결과를 얻음

```
가
나
다
가가
나나
다다
가가가
나나나
다다다
```

* 두 가지 방법
1. 기본 정렬 옵션을 `ko_KR.utf8`로 변경
2. 쿼리마다 정렬 옵션을 `ko_KR.utf8`로 설정

1번 진행 중... ⏩
기본 정렬 옵션을 `ko_KR.utf8`로 변경하려면 데이터베이스를 밀고 다시 만들어야 한다.

<br>

 - 애초에 `Postgres` 기본 정렬 옵션 바꿔보기 ⏩
   - `Postgres` 이미지에는 기본적으로 영문 locale만 추가되어 있음. 
   - 따라서, 한글 utf8을 기본 입력이나, locale로 활용하려고 하는 경우에는 linux localedef 명령어로 추가해주어야 한다.
   - `localedef -f UTF-8 -i ko_KR ko_KR.UTF-8`
   - 위 내용을 진행하지 않은 경우, postgresql/mysql에 있는 ko_kr.utf8 로 만들어진 자료를 import 할 때 오류가 발생한다.
   - `ERROR:  invalid locale name: "ko_KR.UTF-8"`

<참고자료>

[Postgres 커스텀 Dockerfile](https://taejoone.jeju.onl/posts/2022-08-14-postgres-tz-locale-setup/)

[Postgres 이미지에는 기본적으로 영문 locale만 추가 되어 있음.](https://blog.naver.com/kpyopark/220205138327)
